### PR TITLE
ci: tag-based PyPI publishing via OIDC + GitHub Releases + docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false  # don't leave GITHUB_TOKEN in git config; build runs third-party code
         # Submodule (spec/) is not needed — cloudglue/sdk is already committed.
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,8 +69,6 @@ jobs:
           path: dist/
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true  # idempotent: re-running after a successful upload won't fail on a duplicate
 
   github-release:
     name: Create GitHub Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,7 @@ jobs:
       url: https://pypi.org/p/cloudglue
     permissions:
       id-token: write  # required for OIDC trusted publishing
+      actions: read    # allow download-artifact to fetch the build artifact
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -74,6 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # required to create the release and upload assets
+      actions: read    # allow download-artifact to fetch the build artifact
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,8 @@ name: Publish to PyPI
 # Publishes to PyPI via OIDC trusted publishing whenever a v* tag is pushed.
 # No API tokens required — PyPI verifies the GitHub OIDC identity instead.
 #
-#   git tag v0.7.15
-#   git push origin v0.7.15
+#   git tag v0.7.16        # must match the version in pyproject.toml
+#   git push origin v0.7.16
 
 on:
   push:
@@ -35,7 +35,7 @@ jobs:
           PKG_VERSION="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::Tag $GITHUB_REF_NAME (version $TAG_VERSION) does not match pyproject version $PKG_VERSION" >&2
+            echo "::error::Tag $GITHUB_REF_NAME (version $TAG_VERSION) does not match pyproject version $PKG_VERSION"
             exit 1
           fi
           echo "Building and publishing version $PKG_VERSION"
@@ -62,7 +62,6 @@ jobs:
       url: https://pypi.org/p/cloudglue
     permissions:
       id-token: write  # required for OIDC trusted publishing
-      actions: read    # allow download-artifact to fetch the build artifact
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -70,6 +69,8 @@ jobs:
           path: dist/
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true  # idempotent: re-running after a successful upload won't fail on a duplicate
 
   github-release:
     name: Create GitHub Release
@@ -77,7 +78,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # required to create the release and upload assets
-      actions: read    # allow download-artifact to fetch the build artifact
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,3 +65,21 @@ jobs:
           path: dist/
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish  # only release after a successful PyPI publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # required to create the release and upload assets
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create release with sdist + wheel attached
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # for checkout; upload-artifact uses the Actions runtime token, not GITHUB_TOKEN
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,67 @@
+name: Publish to PyPI
+
+# Publishes to PyPI via OIDC trusted publishing whenever a v* tag is pushed.
+# No API tokens required — PyPI verifies the GitHub OIDC identity instead.
+#
+#   git tag v0.7.15
+#   git push origin v0.7.15
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        # Submodule (spec/) is not needed — cloudglue/sdk is already committed.
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+
+      - name: Verify tag matches pyproject version
+        run: |
+          PKG_VERSION="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME (version $TAG_VERSION) does not match pyproject version $PKG_VERSION" >&2
+            exit 1
+          fi
+          echo "Building and publishing version $PKG_VERSION"
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Check artifacts
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cloudglue
+    permissions:
+      id-token: write  # required for OIDC trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -91,6 +91,52 @@ make generate  # Generate SDK from OpenAPI spec
 make build     # Build the package
 ```
 
+### Releasing
+
+Releases are published to PyPI automatically by the
+[`Publish to PyPI`](.github/workflows/publish.yml) GitHub Actions workflow
+whenever a `v*` tag is pushed. It uses
+[OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/) — no API
+tokens are stored anywhere.
+
+To cut a release:
+
+```bash
+# 1. Bump the version in pyproject.toml (e.g. 0.7.15 -> 0.7.16) and commit it.
+# 2. Tag the commit. The tag MUST match the pyproject.toml version, prefixed
+#    with "v" — the workflow fails fast if they differ.
+git tag v0.7.16
+git push origin v0.7.16
+```
+
+Pushing the tag triggers, in order:
+
+1. **build** — verifies the tag matches `pyproject.toml`, builds the sdist +
+   wheel, runs `twine check`.
+2. **publish** — uploads the artifacts to PyPI via OIDC.
+3. **github-release** — creates a [GitHub Release](https://github.com/cloudglue/cloudglue-python/releases)
+   for the tag with auto-generated notes and the `.tar.gz` + `.whl` attached.
+
+#### One-time setup
+
+This is already configured for the `cloudglue` project, but for reference the
+workflow depends on:
+
+- A [PyPI trusted publisher](https://pypi.org/manage/project/cloudglue/settings/publishing/)
+  for repo `cloudglue/cloudglue-python`, workflow `publish.yml`, environment `pypi`.
+- A GitHub Environment named `pypi` (repo **Settings → Environments**).
+
+#### Manual publishing (fallback)
+
+The legacy token-based path still works if you need to publish outside CI. It
+requires a [PyPI API token](https://pypi.org/manage/account/token/) scoped to the
+`cloudglue` project, in `~/.pypirc` or via env vars:
+
+```bash
+make build
+TWINE_USERNAME=__token__ TWINE_PASSWORD='pypi-...' make publish
+```
+
 ### Project Structure
 
 Project directory structure described below:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml`: on every `v*` tag push, build the package, verify the tag matches `pyproject.toml`, publish to PyPI via **OIDC trusted publishing** (no stored tokens), then create a **GitHub Release** with the `.tar.gz` + `.whl` attached.
- Documents the tag-based release flow (and the manual `make publish` fallback) in the README **Releasing** section.
- Hardens the build checkout with `persist-credentials: false`.

## Test plan

**Validated locally on this branch (commit `1c37a57`):**

- [x] **`actionlint` 1.7.12** — clean, no findings (workflow syntax, expression checks, action input schemas, and shellcheck on the `run:` blocks).
- [x] **Version gate** — replicated the exact `Verify tag matches pyproject version` step: matching tag `v0.7.15` → exit 0 (`Building and publishing version 0.7.15`); mismatching tag `v0.7.16` → exit 1 with the `::error::` line emitted on **stdout** (so GitHub renders it as an annotation, not a plain log line).
- [x] **Build job steps** — `python -m build` produces `cloudglue-0.7.15.tar.gz` + `cloudglue-0.7.15-py3-none-any.whl`; `twine check dist/*` → both **PASSED**.
- [x] **Workflow structure** — 3 jobs chained `build → publish → github-release`, trigger `push: tags: [v*]`, minimal per-job permissions (build `contents:read`, publish `id-token:write` + `pypi` environment, github-release `contents:write`).
- [x] **GitHub `pypi` environment** — created and restricted to `v*` tag deployments only.

**Requires a live `v*` tag push (first real release, e.g. `v0.7.16`) — cannot be verified pre-merge:**

- [x] PyPI trusted publisher configured (`cloudglue/cloudglue-python`, workflow `publish.yml`, environment `pypi`).
- [ ] `publish` uploads to PyPI via OIDC with no token prompt.
- [ ] GitHub Release created for the tag with `.tar.gz` + `.whl` attached.

> Note: `0.7.15` is already published on PyPI (immutable), so the first end-to-end run will be the next version bump (`0.7.16`). A failed OIDC handshake does not consume the version, so the first live release doubles safely as the end-to-end test.

## Why

`make publish` requires a long-lived PyPI API token (opaque `403`s when it expires/rotates). Trusted publishing has PyPI verify the GitHub OIDC identity of the run instead, so there's no secret to manage or leak. Attaching dists to a GitHub Release gives a permanent record independent of PyPI.

## Jobs

- **`build`** — checkout (`persist-credentials: false`; submodule intentionally *not* fetched since `cloudglue/sdk` is committed), verify tag matches `pyproject.toml` version (fails fast on mismatch), build sdist + wheel, run `twine check`, upload artifact.
- **`publish`** — download artifact and publish with `pypa/gh-action-pypi-publish` using `id-token: write` and a `pypi` environment.
- **`github-release`** — runs only after a successful publish; creates a GitHub Release with auto-generated notes and the `.tar.gz` + `.whl` attached (`contents: write` scoped to this job).

## Required one-time setup

1. **PyPI** → https://pypi.org/manage/project/cloudglue/settings/publishing/ → add a GitHub trusted publisher: owner `cloudglue`, repo `cloudglue-python`, workflow `publish.yml`, environment `pypi`.
2. **GitHub** → Settings → Environments → create `pypi`.

## Release flow afterwards

```bash
# bump version in pyproject.toml, commit, then:
git tag v0.7.16
git push origin v0.7.16
```

The legacy `make publish` token path still works as a manual fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production packages reach PyPI and require correct trusted-publisher and environment setup; a misconfigured or bypassed tag/version check could publish the wrong version.
> 
> **Overview**
> Adds **automated release CI** triggered by `v*` tags: build verifies the tag matches `pyproject.toml`, produces and checks dist artifacts, publishes to PyPI with **OIDC trusted publishing** (no stored tokens), then creates a **GitHub Release** with the sdist and wheel attached.
> 
> The **README** gains a **Releasing** section (tag flow, one-time PyPI/GitHub `pypi` environment setup, manual `make publish` fallback). The workflow checkout uses **`persist-credentials: false`** and skips the spec submodule because the SDK is already committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c37a57b12589d712ea2ced6d8c8cde4ae6a80e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
