### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the Python SDK for the hosted CloudGlue API. There is no local backend to run — the SDK is a client library.
+
+- Dependencies are installed automatically by the environment update script into a virtualenv at `.venv` (`python3 -m venv .venv` then `pip install -e .`). Use `.venv/bin/python` / `.venv/bin/pip`. Creating a venv requires the system `python3-venv` package, which is provided by the VM image (not the update script).
+- The generated SDK in `cloudglue/sdk/` is **committed**, so `make generate` (which needs `openapi-generator` plus the `spec/` git submodule) and `make setup` are **not** required for day-to-day development. `pip install -e .` is sufficient.
+- There is **no test suite** in this repo. A quick smoke check: `.venv/bin/python -c "from cloudglue import Cloudglue; Cloudglue(api_key='cg-x')"` instantiates the client and wires all resources against `https://api.cloudglue.dev/v1`.
+- Real API calls require a valid `CLOUDGLUE_API_KEY` (keys start with `cg-`) and network access to `api.cloudglue.dev`.
+- Other commands (`make build`, `make generate`, releasing) are documented in `README.md`, `CLAUDE.md`, and the `Makefile`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an `AGENTS.md` documenting how to set up and work in this Python SDK from a Cursor Cloud agent environment.

Key durable notes captured:
- Install into a virtualenv (`python3 -m venv .venv` then `pip install -e .`); venv creation needs the system `python3-venv` package (provided by the VM image, not the update script).
- Generated SDK in `cloudglue/sdk/` is committed, so `make generate`/`make setup` (needing `openapi-generator` + the `spec/` submodule) are **not** required for dev.
- No test suite; a quick smoke check instantiates `Cloudglue(api_key=...)` and wires resources against `https://api.cloudglue.dev/v1`.
- Real API calls need `CLOUDGLUE_API_KEY` + network to `api.cloudglue.dev`.

## Verification

- ✅ `python3 -m venv .venv` + `pip install -e .`
- ✅ `from cloudglue import Cloudglue; Cloudglue(api_key='cg-x')` instantiates with all resources wired

No source code changed; documentation only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e368ecfd-21ad-4222-8776-4e440e84705d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e368ecfd-21ad-4222-8776-4e440e84705d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

